### PR TITLE
Add new options for WHC task customization

### DIFF
--- a/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
+++ b/build-logic/src/main/groovy/org.omegat.document-conventions.gradle
@@ -106,16 +106,16 @@ ext.makeDocumentationTasks = { lang ->
         description 'Build whc contents'
         tocFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/toc.xml"))
         inputFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/index.html"))
-        outputDirectory.set(outputRoot.get().dir("manual/${lang}"))
+        headerFile.set(layout.buildDirectory.file("tmp/manual/${lang}/xhtml5/_header.xhtml"))
+        documentLayout.set('simple')
+        localJQuery.set(true)
         parameterList.set([
-                'layout', 'simple',
-                // 'user-header', "${lang}/xhtml5/_header.xhtml",
                 '--navigation-background-color', '#FDFDFD',
                 '--field-background-color', '#FDFDFD',
                 '--panel-background-color', '#FDFDFD',
-                'local-jquery', 'yes'
         ])
         contentFiles.set(fileTree(dir: layout.buildDirectory.dir("tmp/manual/${lang}/xhtml5"), include: '*.html', exclude: '_*'))
+        outputDirectory.set(outputRoot.get().dir("manual/${lang}"))
         dependsOn(whcHeader, whcToc, whcIndex)
         group('documentation')
     }

--- a/build-logic/src/main/groovy/org/omegat/documentation/WhcTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/WhcTask.groovy
@@ -6,6 +6,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
@@ -27,12 +28,24 @@ class WhcTask extends AbstractDocumentTask {
     @InputFile
     final Provider<RegularFile> tocFile = project.objects.fileProperty()
 
+    @InputFile
+    final Provider<RegularFile> headerFile = project.objects.fileProperty()
+
     @OutputDirectory
     final Provider<Directory> outputDirectory = project.objects.directoryProperty()
 
-    @Option
     @Input
+    @Option
     ListProperty<String> parameterList = project.objects.listProperty(String)
+
+    @Input
+    @Option
+    Property<String> documentLayout = project.objects.property(String)
+
+    @Input
+    @Option
+    Property<Boolean> localJQuery = project.objects.property(Boolean)
+
 
     @TaskAction
     void transform() {
@@ -40,6 +53,13 @@ class WhcTask extends AbstractDocumentTask {
 
         Compiler compiler = new Compiler(null)
         compiler.setVerbose(true)
+        compiler.setUserHeader(headerFile.get().asFile.toPath().toUri().toURL())
+        if (documentLayout.present) {
+            compiler.setLayout(documentLayout.get())
+        }
+        if (localJQuery.present) {
+            compiler.setLocalJQuery(localJQuery.get())
+        }
         File[] contents = contentFiles.get().getFiles().toArray(new File[0])
         if (parameterList.get().size() > 1) {
             compiler.parseParameters((String[])parameterList.get().toArray(StringUtil.EMPTY_LIST))

--- a/src_docs/xsl/whc-header.xsl
+++ b/src_docs/xsl/whc-header.xsl
@@ -1,6 +1,5 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns="http://www.w3.org/1999/xhtml"
-                xmlns:htm="http://www.w3.org/1999/xhtml"
 		        version="1.0">
 
 
@@ -18,7 +17,7 @@
                     <a href="https://omegat.org/">
                         <img alt="OmegaT"
                              height="50" width="100"
-                             src="images/omegat.svg"
+                             src="images/OmegaT.svg"
                              style="border-style: none;"  />
                     </a>
                 </div>


### PR DESCRIPTION
Introduce `headerFile`, `documentLayout`, and `localJQuery` properties to allow better configuration of WHC task. Updated related Gradle scripts to set default values for these properties. Correct image path case sensitivity in whc-header.xsl to ensure compatibility.