### PR TITLE
"Refine TOC XSL templates for improved structure handling

### DIFF
--- a/src_docs/xsl/whc-toc.xsl
+++ b/src_docs/xsl/whc-toc.xsl
@@ -2,28 +2,29 @@
                 xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:whc="http://www.xmlmind.com/whc/schema/whc"
                 xmlns:htm="http://www.w3.org/1999/xhtml"
-		        version="1.0">
+                version="1.0">
+
+    <xsl:output method="xml" indent="yes"/>
 
     <xsl:template match="/">
         <whc:toc>
-            <xsl:apply-templates select="//htm:div[@class='toc']/htm:ul"/>
+            <!-- Apply templates only to the top-level 'ul' elements in the 'list-of-titles' -->
+            <xsl:apply-templates select="//htm:div[@class='list-of-titles']//htm:ul[@class='toc']"/>
         </whc:toc>
     </xsl:template>
 
     <xsl:template name="toc.item">
-        <whc:entry href="{htm:span/htm:a/@href}">
+        <whc:entry href="{htm:a/@href}">
             <whc:title>
-                <xsl:value-of select="htm:span/htm:a"/>
+                <!-- Extract and combine title text -->
+                <xsl:apply-templates select="htm:a//text()"/>
             </whc:title>
-            <xsl:apply-templates select="htm:ul"/>
+            <!-- Only process direct child <li> elements nested under the current <ul> -->
+            <xsl:apply-templates select="htm:ul[@class='toc']/htm:li"/>
         </whc:entry>
     </xsl:template>
 
-    <xsl:template match="htm:li">
-        <xsl:call-template name="toc.item"/>
-    </xsl:template>
-
-    <xsl:template match="htm:li" mode="appendices">
+    <xsl:template match="htm:ul[@class='toc']/htm:li">
         <xsl:call-template name="toc.item"/>
     </xsl:template>
 


### PR DESCRIPTION
Updated XSL templates to handle 'toc' and 'list-of-titles' more precisely by targeting specific structures. Simplified logic for TOC 'entry' creation and ensured proper child element processing. Added indentation and comments for better readability and maintainability."