### PR TITLE
bug: set debug flag to mediaobject-input-uri

### DIFF
--- a/build-logic/src/main/groovy/org/omegat/documentation/DocbookHtmlTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/DocbookHtmlTask.groovy
@@ -14,9 +14,11 @@ class DocbookHtmlTask extends TransformationTask {
 
     @Override
     protected void preTransform(XsltTransformer transformer, File source, File target) {
-        def baseDir = Paths.get(outputFile.get().asFile.parent).toUri().toString()
+        def outputBaseDir = Paths.get(outputFile.get().asFile.parent).toUri().toString()
+        def inputBaseDir = Paths.get(inputFile.get().asFile.parent).toUri().toString()
         transformer.setParameter(new QName("chunk"), new XdmAtomicValue("index.html"))
-        transformer.setParameter(new QName("chunk-output-base-uri"), new XdmAtomicValue(baseDir))
+        transformer.setParameter(new QName("chunk-output-base-uri"), new XdmAtomicValue(outputBaseDir))
+        transformer.setParameter(new QName("mediaobject-input-base-uri"), new XdmAtomicValue(inputBaseDir))
         transformer.setParameter(new QName("resource-base-uri"), new XdmAtomicValue(""))
         transformer.setParameter(new QName("persistent-toc"), new XdmAtomicValue(false))
         transformer.setParameter(new QName("persistent-toc-search"), new XdmAtomicValue(false))

--- a/build-logic/src/main/groovy/org/omegat/documentation/TransformationTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/TransformationTask.groovy
@@ -3,7 +3,9 @@ package org.omegat.documentation
 import groovy.transform.CompileStatic
 import net.sf.saxon.lib.ResourceResolverWrappingURIResolver
 import net.sf.saxon.s9api.Processor
+import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.Serializer
+import net.sf.saxon.s9api.XdmAtomicValue
 import net.sf.saxon.s9api.XsltCompiler
 import net.sf.saxon.s9api.XsltExecutable
 import net.sf.saxon.s9api.XsltTransformer
@@ -88,6 +90,7 @@ class TransformationTask extends AbstractDocumentTask {
         Processor processor = new Processor(false)
         XsltCompiler compiler = processor.newXsltCompiler()
         compiler.setResourceResolver(initializeResourceResolver())
+        compiler.setParameter(new QName("debug"), new XdmAtomicValue("mediaobject-uris"))
 
         // Compile the XSLT stylesheet
         XsltExecutable executable = compiler.compile(new StreamSource(xslFile))


### PR DESCRIPTION
```> Task :docbookHtmlEn
Build cache key for task ':docbookHtmlEn' is 6ed736505f925e6c81166a800e668b3f
Task ':docbookHtmlEn' is not up-to-date because:
  Input property 'styleSheetFile' file /home/miurahr/IdeaProjects/omegat-manual/src_docs/xsl/db5-xhtml.xsl has changed.

  xml baseuri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/Introduction.xml
  m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
f:m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
      fileref: images/defaultOmegaTLayout.png
     base-uri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
          uri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/images/defaultOmegaTLayout.png
     relative → images/defaultOmegaTLayout.png
Cannot read image properties (no extension)

  xml baseuri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/OmegaT_EditorsPanes.xml
  m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
f:m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
      fileref: images/defaultOmegaTLayout.png
     base-uri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
          uri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/images/defaultOmegaTLayout.png
     relative → images/defaultOmegaTLayout.png
Cannot read image properties (no extension)

  xml baseuri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/OmegaT_EditorsPanes.xml
  m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
f:m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
      fileref: images/Settings.png
     base-uri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
          uri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/images/Settings.png
     relative → images/Settings.png
Cannot read image properties (no extension)

  xml baseuri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/OmegaT_EditorsPanes.xml
  m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
f:m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
      fileref: images/Minimize.png
     base-uri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
          uri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/images/Minimize.png
     relative → images/Minimize.png
Cannot read image properties (no extension)

  xml baseuri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/OmegaT_EditorsPanes.xml
  m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
f:m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
      fileref: images/Maximize.png
     base-uri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
          uri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/images/Maximize.png
     relative → images/Maximize.png
Cannot read image properties (no extension)

  xml baseuri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/OmegaT_EditorsPanes.xml
  m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
f:m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
      fileref: images/Restore.png
     base-uri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
          uri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/images/Restore.png
     relative → images/Restore.png
Cannot read image properties (no extension)

  xml baseuri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/OmegaT_EditorsPanes.xml
  m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
f:m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
      fileref: images/Undock.png
     base-uri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
          uri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/images/Undock.png
     relative → images/Undock.png
Cannot read image properties (no extension)

  xml baseuri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/OmegaT_EditorsPanes.xml
  m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
f:m/o baseuri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
      fileref: images/Dock.png
     base-uri: file:///home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/
          uri: file:/home/miurahr/IdeaProjects/omegat-manual/src_docs/manual/en/images/Dock.png
     relative → images/Dock.png
Cannot read image properties (no extension)
Link to non-existent ID: project.folder.omegat.ignored.words
Cleanup img: images/defaultOmegaTLayout.png 	→ ../../../../../../../..///home/miurahr/IdeaProjects/omegat-manual/build/tmp/manual/en/images/defaultOmegaTLayout.png
Cleanup img: images/defaultOmegaTLayout.png 	→ ../../../../../../../..///home/miurahr/IdeaProjects/omegat-manual/build/tmp/manual/en/images/defaultOmegaTLayout.png
Cleanup img: images/Settings.png 	→ ../../../../../../../..///home/miurahr/IdeaProjects/omegat-manual/build/tmp/manual/en/images/Settings.png
Cleanup img: images/Minimize.png 	→ ../../../../../../../..///home/miurahr/IdeaProjects/omegat-manual/build/tmp/manual/en/images/Minimize.png
Cleanup img: images/Maximize.png 	→ ../../../../../../../..///home/miurahr/IdeaProjects/omegat-manual/build/tmp/manual/en/images/Maximize.png
Cleanup img: images/Restore.png 	→ ../../../../../../../..///home/miurahr/IdeaProjects/omegat-manual/build/tmp/manual/en/images/Restore.png
Cleanup img: images/Undock.png 	→ ../../../../../../../..///home/miurahr/IdeaProjects/omegat-manual/build/tmp/manual/en/images/Undock.png
Cleanup img: images/Dock.png 	→ ../../../../../../../..///home/miurahr/IdeaProjects/omegat-manual/build/tmp/manual/en/images/Dock.png
Stored cache entry for task ':docbookHtmlEn' with cache key 6ed736505f925e6c81166a800e668b3f
Resolve mutations for :whcTocEn (Thread[Execution worker Thread 7,5,main]) started.
:whcTocEn (Thread[Execution worker Thread 6,5,main]) started.
```