### PR TITLE
fix(xslt): correct header title XPath to match DocBook namespace

### DIFF
--- a/src_docs/xsl/whc-header.xsl
+++ b/src_docs/xsl/whc-header.xsl
@@ -1,6 +1,6 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns="http://www.w3.org/1999/xhtml"
-                xmlns:htm="http://www.w3.org/1999/xhtml"
+                xmlns:db="http://docbook.org/ns/docbook"
 		        version="1.0">
 
 
@@ -25,7 +25,7 @@
 
                 <div class="title">
                     <a href="index.html">
-                        <xsl:value-of select="book/bookinfo/title"/>
+                        <xsl:value-of select="/db:book/db:info/db:title"/>
                     </a>
                 </div>
             </body>


### PR DESCRIPTION
This Pull Request modifies the whc-header.xsl file to update the XML namespace and change the XPath expressions used to extract the book title for a link.
# Main changes:
- Updated the namespace xmlns:htm to xmlns:db pointing to the DocBook XML namespace.
- Adjusted the XPath query to use the db: namespace for selecting the book title, likely aligning with the updated DocBook structure.