### PR TITLE
feat(DocbookHtmlTask, TransformationTask): register DocBook XSLT extension

### DIFF
--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation 'org.xmlresolver:xmlresolver:5.2.2'
     implementation 'net.sf.saxon:Saxon-HE:12.5'
     implementation 'org.docbook:docbook-xslTNG:2.5.0'
+    implementation 'com.nwalsh:sinclude:5.2.4'
     implementation 'tokyo.northside:whc:3.6.0'
     implementation 'xalan:xalan:2.7.3'
     implementation 'xalan:serializer:2.7.3'

--- a/build-logic/src/main/groovy/org/omegat/documentation/DocbookHtmlTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/DocbookHtmlTask.groovy
@@ -1,9 +1,15 @@
 package org.omegat.documentation
 
 import groovy.transform.CompileStatic
+import net.sf.saxon.s9api.Processor
 import net.sf.saxon.s9api.QName
 import net.sf.saxon.s9api.XdmAtomicValue
 import net.sf.saxon.s9api.XsltTransformer
+import org.docbook.xsltng.extensions.Cwd
+import org.docbook.xsltng.extensions.ImageMetadata
+import org.docbook.xsltng.extensions.ImageProperties
+import org.docbook.xsltng.extensions.Register
+import org.docbook.xsltng.extensions.XInclude
 import org.gradle.api.tasks.CacheableTask
 
 import java.nio.file.Paths
@@ -11,6 +17,12 @@ import java.nio.file.Paths
 @CompileStatic
 @CacheableTask
 class DocbookHtmlTask extends TransformationTask {
+
+    @Override
+    protected void configProcessor(Processor processor) {
+        Register register = new Register()
+        register.initialize(processor.getUnderlyingConfiguration())
+    }
 
     @Override
     protected void preTransform(XsltTransformer transformer, File source, File target) {

--- a/build-logic/src/main/groovy/org/omegat/documentation/TransformationTask.groovy
+++ b/build-logic/src/main/groovy/org/omegat/documentation/TransformationTask.groovy
@@ -81,6 +81,9 @@ class TransformationTask extends AbstractDocumentTask {
     protected void postTransform(File output) {
     }
 
+    protected void configProcessor(Processor processor) {
+    }
+
     private static XMLReader initializeXmlReader() {
         def factory = configureSAXParserFactory()
         def xmlReader = factory.newSAXParser().getXMLReader()
@@ -92,6 +95,7 @@ class TransformationTask extends AbstractDocumentTask {
 
         // Set up Saxon Processor
         Processor processor = new Processor(false)
+        configProcessor(processor)
         XsltCompiler compiler = processor.newXsltCompiler()
         compiler.setResourceResolver(initializeResourceResolver())
         if (debug.present) {


### PR DESCRIPTION
- Added functionality to register DocBook XSLT extension functions in `DocbookHtmlTask` via the new `configProcessor` method.
- Updated `TransformationTask` to include a `configProcessor` method for optional processor configuration.
- Added `com.nwalsh:sinclude:5.2.4` dependency to support these extensions.